### PR TITLE
Issue #73 - Remove speed restrictions for fake hardware

### DIFF
--- a/roboplot/config.py
+++ b/roboplot/config.py
@@ -10,3 +10,6 @@ import os
 # File Paths
 roboplot_directory = os.path.dirname(os.path.realpath(os.path.join(os.getcwd(), os.path.expanduser(__file__))))
 resources_dir = os.path.normpath(os.path.join(roboplot_directory, '..', 'resources'))
+
+# Environment variables
+real_hardware = os.environ.get('ROBOPLOT', 0) != 0

--- a/roboplot/core/gpio/gpio_wrapper.py
+++ b/roboplot/core/gpio/gpio_wrapper.py
@@ -11,7 +11,9 @@ variables available:
 
 import os
 
-is_emulator = os.environ.get('ROBOPLOT', 0) == 0
+import roboplot.config as config
+
+is_emulator = not config.real_hardware
 
 if is_emulator:
     from roboplot.core.gpio.EmulatorGUI import GPIO, app

--- a/roboplot/core/stepper_motors.py
+++ b/roboplot/core/stepper_motors.py
@@ -17,7 +17,7 @@ class StepperMotor:
     steps_per_revolution = 0
     clockwise = True
     _next_step = 0
-    _minimum_seconds_between_steps = 0.001
+    _minimum_seconds_between_steps = 0.001 if config.real_hardware else 0
     _earliest_next_step = time.time()
 
     def __init__(self, pins, sequence, steps_per_revolution, minimum_seconds_between_steps=_minimum_seconds_between_steps):

--- a/roboplot/core/stepper_motors.py
+++ b/roboplot/core/stepper_motors.py
@@ -7,6 +7,7 @@ Authors:
 
 import time
 
+import roboplot.config as config
 from roboplot.core.gpio.gpio_wrapper import GPIO
 
 
@@ -19,7 +20,7 @@ class StepperMotor:
     _minimum_seconds_between_steps = 0.001
     _earliest_next_step = time.time()
 
-    def __init__(self, pins, sequence, steps_per_revolution, minimum_seconds_between_steps=0.001):
+    def __init__(self, pins, sequence, steps_per_revolution, minimum_seconds_between_steps=_minimum_seconds_between_steps):
         """
         Initialises the Motor class.
 

--- a/roboplot/core/stepper_motors.py
+++ b/roboplot/core/stepper_motors.py
@@ -17,7 +17,7 @@ class StepperMotor:
     steps_per_revolution = 0
     clockwise = True
     _next_step = 0
-    _minimum_seconds_between_steps = 0.001 if config.real_hardware else 0
+    _minimum_seconds_between_steps = 0.001 if config.real_hardware else 0.0
     _earliest_next_step = time.time()
 
     def __init__(self, pins, sequence, steps_per_revolution, minimum_seconds_between_steps=_minimum_seconds_between_steps):


### PR DESCRIPTION
Currently on master:
  - There is a minimum of 1ms delay between steps on a single motor

With this bugfix:
  - The delay is set to 0 if the `ROBOPLOT` environment variable is not defined
  - Unfortunately in practice a step seems to take about that order of time anyway (with needing to update the GUI and plot progress on a simulated image). It is a little quicker though.