### PR TITLE
Issue #147 - Control servo power

### DIFF
--- a/roboplot/core/gpio/EmulatorGUI.py
+++ b/roboplot/core/gpio/EmulatorGUI.py
@@ -407,6 +407,7 @@ class GPIO:
             drawBindUpdateButtonIn(str(channel), objTemp.In)
             dictionaryPins[str(channel)] = objTemp
 
+    @staticmethod
     @typeassert(int, int)
     def output(channel, outmode):
         global dictionaryPins

--- a/roboplot/core/hardware.py
+++ b/roboplot/core/hardware.py
@@ -22,11 +22,10 @@ import roboplot.core.stepper_control as stepper_control
 x_axis_motor = stepper_motors.large_stepper_motor(gpio_pins=(22, 23, 24, 25))
 y_axis_motor = stepper_motors.large_stepper_motor(gpio_pins=(19, 26, 20, 21))
 
-small_stepper_1 = stepper_motors.small_stepper_motor(gpio_pins=(5, 6, 12, 16))
-small_stepper_2 = stepper_motors.small_stepper_motor(gpio_pins=(2, 3, 4, 17))
+# small_stepper_1 = stepper_motors.small_stepper_motor(gpio_pins=(5, 6, 12, 16))  # Pin 5 is now for the servo power
+# small_stepper_2 = stepper_motors.small_stepper_motor(gpio_pins=(2, 3, 4, 17))
 
-# TODO: Choose a pin to control the power to the servo motor
-servo = servo_motor.ServoMotor(power_control_pin=,
+servo = servo_motor.ServoMotor(power_control_pin=5,
                                pwm_pin=18,
                                min_position=0.03,
                                max_position=0.12)

--- a/roboplot/core/hardware.py
+++ b/roboplot/core/hardware.py
@@ -25,7 +25,9 @@ y_axis_motor = stepper_motors.large_stepper_motor(gpio_pins=(19, 26, 20, 21))
 small_stepper_1 = stepper_motors.small_stepper_motor(gpio_pins=(5, 6, 12, 16))
 small_stepper_2 = stepper_motors.small_stepper_motor(gpio_pins=(2, 3, 4, 17))
 
-servo = servo_motor.ServoMotor(gpio_pin=18,
+# TODO: Choose a pin to control the power to the servo motor
+servo = servo_motor.ServoMotor(power_control_pin=,
+                               pwm_pin=18,
                                min_position=0.03,
                                max_position=0.12)
 

--- a/roboplot/core/servo_motor.py
+++ b/roboplot/core/servo_motor.py
@@ -5,32 +5,38 @@ import time
 import numpy as np
 
 import roboplot.core.gpio.wiringpi_wrapper as wiringpi_wrapper
+from roboplot.core.gpio.gpio_wrapper import GPIO
 
 
 class ServoMotor:
-    def __init__(self, min_position: float, max_position: float, gpio_pin: int = 18):
+    def __init__(self, min_position: float, max_position: float, power_control_pin: int, pwm_pin: int = 18):
         """
         Create a servo motor driver.
 
         Args:
-            gpio_pin (int): the BCM gpio pin (should be 18 since this is the only hardware pwm pin)
             min_position (float): the minimum (safe) input to the servo motor
             max_position (float): the maximum (safe) input to the servo motor
+            power_control_pin (int): the BCM gpio pin used to switch on and off the power to the servo motor
+            pwm_pin (int): the BCM gpio pin for pwm (should be 18 since this is the only hardware pwm pin)
         """
 
-        if not gpio_pin == 18:
+        if not pwm_pin == 18:
             # Can't do this more naturally because I don't fully understand the scope of the wiringpi.pwmSetMode,
             # pwmSetRange and pwmSetClock methods.
-            # I've kept the gpio_pin argument so that we can write it explicitly in the hardware class. An
+            # I've kept the pwm_pin argument so that we can write it explicitly in the hardware class. An
             # alternative would be to make a factory method on the Servo class called create_on_pin_18() or similar.
             raise ValueError("Setting up servo motor on a pin other than 18. BCM pin 18 is the only hardware pwm pin.")
 
         assert 0 <= min_position <= max_position <= 1
 
         wiringpi_wrapper.setup_pwm_pin_18(initial_value=0)
+        GPIO.setup(power_control_pin, GPIO.OUT)
+        GPIO.output(power_control_pin, False)
+
         self._last_set_position = 0
         self.min_position = min_position
         self.max_position = max_position
+        self._power_control_pin = power_control_pin
 
     def move_smoothly_to(self, target_position: float, seconds_to_take: float) -> None:
         """
@@ -72,6 +78,7 @@ class ServoMotor:
                                                                                           self.min_position,
                                                                                           self.max_position)
         wiringpi_wrapper.write_pwm_to_pin_18(self._required_output(pwm_input))
+        GPIO.output(self._power_control_pin, True)
         self._last_set_position = pwm_input
 
     def input_is_in_range(self, pwm_input):
@@ -92,9 +99,9 @@ class ServoMotor:
         """
         return int(round(pwm_input * wiringpi_wrapper.pwm_pin.pwm_range))
 
-    # noinspection PyMethodMayBeStatic
-    def stop_pwm(self):
-        """Note that the servo motor will still remain engaged after the pi ceases to send a pwm signal."""
+    def disengage(self):
+        """Cut the power to the servo and stop sending pwm."""
+        GPIO.output(self._power_control_pin, False)
         wiringpi_wrapper.write_pwm_to_pin_18(0)
 
 

--- a/scripts/set_pen_position.py
+++ b/scripts/set_pen_position.py
@@ -23,4 +23,5 @@ try:
         raise ValueError('Bad input!')  # Shouldn't get here since argument parser will catch invalid arguments
 
 finally:
-    GPIO.cleanup()
+    # GPIO.cleanup()
+    pass

--- a/scripts/set_servo.py
+++ b/scripts/set_servo.py
@@ -25,4 +25,5 @@ try:
         print('Success')
 
 finally:
-    GPIO.cleanup()
+    #GPIO.cleanup()
+    pass

--- a/scripts/set_servo.py
+++ b/scripts/set_servo.py
@@ -11,11 +11,18 @@ try:
     parser.add_argument('position', type=float,
                         help="The position to set on the servo "
                              "(this is a proportion of the maximum pwm frequency set up on the pi). "
-                             "This should be between {} and {}".format(hardware.servo.min_position,
-                                                                             hardware.servo.max_position))
+                             "This should be between {} and {}, or 0.".format(hardware.servo.min_position,
+                                                                              hardware.servo.max_position))
     args = parser.parse_args()
 
-    hardware.servo.set_position(args.position)
+    if args.position == 0:
+        print('Disengaging servo... ', end='')
+        hardware.servo.disengage()
+        print('Success')
+    else:
+        print('Setting servo to {}...'.format(args.position), end='')
+        hardware.servo.set_position(args.position)
+        print('Success')
 
 finally:
     GPIO.cleanup()


### PR DESCRIPTION
While this may not be the final way we want to implement this, we need it for tomorrow if we want to be able to control the pen on any other branch.
Therefore, I'm merging it without review (it can't make the situation worse!) but I'll keep the issue open for any review comments which get made post-merge.

Some questions for the final design:
  - Do we want the servo power GPIO pin to be cleaned up at the end of the scripts? (The current behaviour). This will mean that the servo will always be disengaged during scripts until its position is set. It's worth noting that all 'public' methods on the `plotter` set the pen position, so this *should* be quite easy to achieve (but I may have missed something!!). The `set_pen_position.py` and `set_servo.py` scripts can easily be modified to run as mini-interactive environments (for example) to still allow us to test different pen positions and exercise the servo motor.
  - Alternatively, we can leave the servo power and pwm signal running at the end of scripts. This would require implementing a separate `hardware.cleanup` function and changing all callers of `GPIO.cleanup`. It would also mean modifying the `gpio_wrapper` to record pins set-up through the `GPIO.setup` calls, so that it can clean up all except for the servo power pin when called by `hardware.cleanup`.